### PR TITLE
Allow a useHomeToken & tokenFile parameter options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,9 @@ let tv4 = require('tv4');
 let commands = require('./commands.js');
 let mustache = require('mustache');
 let rp = require('request-promise-native');
+const fs = require('fs');
+const os = require('os');
+const pathJoin = require('path').join;
 
 module.exports = (config = {}) => {
   // load conditional dependencies
@@ -46,6 +49,19 @@ module.exports = (config = {}) => {
   client.apiVersion = config.apiVersion || 'v1';
   client.endpoint = config.endpoint || process.env.VAULT_ADDR || 'http://127.0.0.1:8200';
   client.token = config.token || process.env.VAULT_TOKEN;
+
+  // A few other means of token retrieval
+  if (config.useHomeToken === true && !config.tokenFile) {
+    config.tokenFile = pathJoin(os.homedir(), '.vault-token');
+  }
+  // Allow token retrieval via file
+  if (config.tokenFile) {
+    try {
+      client.token = fs.readFileSync(config.tokenFile).toString();
+    } catch (ex) {
+      // pass
+    }
+  }
 
   const requestSchema = {
     type: 'object',


### PR DESCRIPTION
Our usage of the node-vault library typically involves a thin wrapper to get the authentication token from various locations. Partly for the development experience, but absolutely as a deployment strategy. I am proposing two new configuration parameters `useHomeToken` and `tokenFile`.

`useHomeToken` is useful because `$ vault login` places a copy of the token in `~/.vault-token` (https://www.vaultproject.io/docs/commands/token-helper.html). This would allow local development to automatically negotiate with the user that is already logged into the system.

`tokenFile` is useful because of our deployment strategy. We have a docker / kubernetes environment for hosting our applications, and part of the orchestration is a docker container that does the vault authentication for us and places a token on the disk. There does not seem to be a native way to use a token file, so this adds it in.

If this approach is appreciable, I can update the tests 👍 