### PR TITLE
Move Request types to dependencies & fix functionConf type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare namespace NodeVault {
     interface functionConf {
         method: string;
         path: string;
+        tokenSource?: boolean;
         schema?: {
             req?: Option;
             query?: Option;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "index.d.ts"
   ],
   "dependencies": {
+    "@types/request": "^2.48.1",
     "debug": "3.1.0",
     "mustache": "^2.2.1",
     "request": "2.88.0",
@@ -33,7 +34,6 @@
     "snyk": "^1.189.0"
   },
   "devDependencies": {
-    "@types/request": "^2.48.1",
     "chai": "3.5.0",
     "dirty-chai": "^1.2.2",
     "docco": "0.8.0",


### PR DESCRIPTION
@types/request needs to be a dependency instead of devDependency. If we build a library with node-vault as dependency, @types/request are missing

It also fixes functionConf type