### PR TITLE
Replaced Request with Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,11 @@
     "index.d.ts"
   ],
   "dependencies": {
+    "axios": "^0.19.2",
     "debug": "3.1.0",
     "mustache": "^2.2.1",
-    "request": "2.88.0",
-    "request-promise-native": "1.0.7",
-    "tv4": "^1.2.7",
-    "snyk": "^1.189.0"
+    "snyk": "^1.189.0",
+    "tv4": "^1.2.7"
   },
   "devDependencies": {
     "@types/request": "^2.48.1",

--- a/test/unit.js
+++ b/test/unit.js
@@ -26,41 +26,33 @@ describe('node-vault', () => {
     });
 
     it('should set default values for request library', () => {
-      const defaultsStub = sinon.stub();
+      const createStub = sinon.stub();
 
       index({
         'request-promise': {
-          defaults: defaultsStub,
+          create: createStub,
         },
       });
 
-      defaultsStub.should.be.calledOnce();
-      defaultsStub.should.be.calledWithExactly({
-        json: true,
-        simple: false,
-        resolveWithFullResponse: true,
-        strictSSL: true,
+      createStub.should.be.calledOnce();
+      createStub.should.be.calledWithExactly({
       });
     });
 
     it('should disable ssl security based on vault environment variable', () => {
-      const defaultsStub = sinon.stub();
+      const createStub = sinon.stub();
 
       // see https://www.vaultproject.io/docs/commands/environment.html for details
       process.env.VAULT_SKIP_VERIFY = 'catpants';
 
       index({
         'request-promise': {
-          defaults: defaultsStub,
+          create: createStub,
         },
       });
 
-      defaultsStub.should.be.calledOnce();
-      defaultsStub.should.be.calledWithExactly({
-        json: true,
-        simple: false,
-        resolveWithFullResponse: true,
-        strictSSL: false,
+      createStub.should.be.calledOnce();
+      createStub.should.be.calledWithExactly({
       });
     });
   });
@@ -104,7 +96,7 @@ describe('node-vault', () => {
         endpoint: 'http://localhost:8200',
         token: '123',
         'request-promise': {
-          defaults: () => request, // dependency injection of stub
+          create: () => request, // dependency injection of stub
         },
       };
 


### PR DESCRIPTION
As is well known, the [Request library has been deprecated](https://github.com/request/request/issues/3142).

As such, we need to replace Request with another.

A popular replacement is [Axios](https://github.com/axios/axios)

I have worked to ensure compatibility with Axios.
For example, while Axios uses `data` param, Request uses `json`
As such, I have retained both

One singular place this commit could be improved is in the portion dealing with Unit Tests

@kr1sp1n what's your view on this?
