### PR TITLE
Changed write method from PUT to POST

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ module.exports = (config = {}) => {
         const options = { ...config.requestOptions, ...requestOptions };
         options.path = `/${path}`;
         options.json = data;
-        options.method = 'PUT';
+        options.method = 'POST';
         return client.request(options);
     };
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -194,7 +194,7 @@ describe('node-vault', () => {
                     value: 'world',
                 };
                 const params = {
-                    method: 'PUT',
+                    method: 'POST',
                     uri: getURI(path),
                 };
                 vault.write(path, data)
@@ -208,7 +208,7 @@ describe('node-vault', () => {
                     value: 'world',
                 };
                 const params = {
-                    method: 'PUT',
+                    method: 'POST',
                     uri: getURI(path),
                 };
                 vault.write(path, data)


### PR DESCRIPTION
Per the Vault API, version 1 of the K/V engine supports both PUT and POST methods when creating/updating secrets. But version 2 of the K/V engine only support POST.

This change updates the method used to write data from PUT to POST in order to provide better continuity for the K/V secrets engine, as well as align with other engines (AWS, Azure, GCP, et. al.) that only support POSTs. 