### PR TITLE
fix for https://github.com/nodevault/node-vault/issues/143

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ vault.write('secret/hello', { value: 'world', lease: '1s' })
 .then( () => vault.delete('secret/hello'))
 .catch(console.error);
 ```
+### Kubernetes Auth Example
+```javascript
+
+//if vault kubernets endpoint is /auth/example-cluster/login and role is example-role
+//read token from default token mount path
+const token = await fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', { encoding: 'utf8' });
+vault.kubernetesLogin({role: 'example-role' ,
+            jwt: token,
+            kubernetesPath: 'example-cluster'})
+```
 
 ## Docs
 Just generate [docco] docs via `npm run docs`.

--- a/src/commands.js
+++ b/src/commands.js
@@ -205,7 +205,7 @@ module.exports = {
     },
     addKubernetesRole: {
         method: 'POST',
-        path: '/auth/{{mount_point}}{{^mount_point}}kubernetes{{/mount_point}}/role/{{ role_name }}',
+        path: '/auth/{{mount_point}}{{^mount_point}}{{kubernetesPath}}{{/mount_point}}/role/{{ role_name }}',
         schema: {
             req: {
                 name: {
@@ -240,14 +240,14 @@ module.exports = {
     },
     getKubernetesRole: {
         method: 'GET',
-        path: '/auth/{{mount_point}}{{^mount_point}}kubernetes{{/mount_point}}/role/{{ role_name }}',
+        path: '/auth/{{mount_point}}{{^mount_point}}{{kubernetesPath}}{{/mount_point}}/role/{{ role_name }}',
         schema: {
             res: kubernetesRoleResponse,
         },
     },
     deleteKubernetesRole: {
         method: 'DELETE',
-        path: '/auth/{{mount_point}}{{^mount_point}}kubernetes{{/mount_point}}/role/{{ role_name }}',
+        path: '/auth/{{mount_point}}{{^mount_point}}{{kubernetesPath}}{{/mount_point}}/role/{{ role_name }}',
     },
     addApproleRole: {
         method: 'POST',
@@ -611,7 +611,7 @@ module.exports = {
     },
     kubernetesLogin: {
         method: 'POST',
-        path: '/auth/{{mount_point}}{{^mount_point}}kubernetes{{/mount_point}}/login',
+        path: '/auth/{{mount_point}}{{^mount_point}}{{kubernetesPath}}{{/mount_point}}/login',
         tokenSource: true,
         schema: {
             req: {
@@ -742,7 +742,7 @@ module.exports = {
             },
             res: tokenResponse,
         },
-    },  
+    },
     tokenAccessors: {
         method: 'LIST',
         path: '/auth/token/accessors',

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ module.exports = (config = {}) => {
     client.token = config.token || process.env.VAULT_TOKEN;
     client.noCustomHTTPVerbs = config.noCustomHTTPVerbs || false;
     client.namespace = config.namespace || process.env.VAULT_NAMESPACE;
+    client.kubernetesPath = config.kubernetesPath || 'kubernetes';
 
     const requestSchema = {
         type: 'object',


### PR DESCRIPTION
kubernetes path can be provided in vault when creating the auth when running a multicluster setup. defaults to kubernetes.

Tested in my test cluster using the new modules and connects to vault and able to retrive data in vault using vault.read after running vault. kubernetesLogin()