### PR TITLE
Fix | Use compose action

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -33,16 +33,20 @@ jobs:
     env:
       NODE_VERSION: ${{ matrix.node_version }}
     steps:
+      - name: Install docker-compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
       - uses: actions/checkout@v3
         with:
           # Fetch all history for all tags and branches
           fetch-depth: 0
       - name: Build the stack
-        run: docker-compose up -d
+        run: docker-compose -f docker-compose.yml up -d
       - name: Build testing container
         run: docker build -t tests:${{ github.sha }} --build-arg SET_NODE_VERSION=$NODE_VERSION .
       - name: Invoke testing container
-        run: docker run --network container:vault
+        run: docker run --network vault-network
           -e VAULT_ADDR=$VAULT_ADDR
           -v $PWD/coverage:/app/coverage tests:${{ github.sha }} "cd /app && npm run coverage"
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - "8200:8200"
     depends_on:
       - postgres
+    networks:
+      - vault-network
 
   postgres:
     image: postgres:15.3
@@ -21,3 +23,10 @@ services:
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: test
+    networks:
+      - vault-network
+
+networks:
+  vault-network:
+    name: vault-network
+    driver: bridge


### PR DESCRIPTION
As seen in https://github.com/nodevault/node-vault/actions/runs/13224738209/job/36914192419?pr=244, `docker-compose` isn't always available on the machine.

Adding the usage of https://github.com/marketplace/actions/docker-compose-action in order to simplify and solve that